### PR TITLE
Change MyPy arguments to remove requirement for __init__.py everywhere

### DIFF
--- a/examples/design/daemon_example.py
+++ b/examples/design/daemon_example.py
@@ -1,5 +1,5 @@
 from itsim import _Packet
-from itsim.machine.process_management import _Thread
+from itsim.machine.process_management.__init__ import _Thread
 from itsim.machine.process_management.daemon import Daemon
 from itsim.network.internet import Host
 from itsim.network.location import Location

--- a/itsim/machine/file_system/__init__.py
+++ b/itsim/machine/file_system/__init__.py
@@ -2,7 +2,7 @@ from inspect import getfullargspec
 
 from itsim import ITObject
 from itsim.machine.file_system.access_policies import Policy
-from itsim.machine.user_management import UserAccount
+from itsim.machine.user_management.__init__ import UserAccount
 
 from sys import getsizeof
 

--- a/itsim/machine/file_system/access_policies.py
+++ b/itsim/machine/file_system/access_policies.py
@@ -12,7 +12,7 @@ dictionaries mapping from :py:class:`~itsim.machine.accounts.UserAccount` and
 :py:class:`~itsim.machine.file_system.access_policies.TargetedPolicy` objects.
 """
 from itsim import ITObject
-from itsim.machine.user_management import UserAccount, UserGroup
+from itsim.machine.user_management.__init__ import UserAccount, UserGroup
 
 from typing import Dict
 

--- a/itsim/machine/node.py
+++ b/itsim/machine/node.py
@@ -14,11 +14,11 @@ from itsim.network import _Link
 from itsim.network.connection import Connection
 from itsim.network.location import AddressInUse, InvalidAddress, Location
 from itsim.network.packet import Payload, Packet
-from itsim.machine.file_system import File
-from itsim.machine.process_management import _Daemon
+from itsim.machine.file_system.__init__ import File
+from itsim.machine.process_management.__init__ import _Daemon
 from itsim.machine.process_management.process import Process
 from itsim.machine.process_management.thread import Thread
-from itsim.machine.user_management import UserAccount
+from itsim.machine.user_management.__init__ import UserAccount
 from itsim.simulator import Simulator
 from itsim.types import Address, AddressRepr, as_port, Port, PortRepr, Protocol
 
@@ -188,13 +188,13 @@ class Node(_Node):
     def procs(self) -> Set[Process]:
         return self._proc_set
 
-    def fork_exec_in(self, sim: Simulator, time: float, f: Callable[[Thread], None], *args, **kwargs) -> Process:
+    def fork_exec_in(self, sim: Simulator, time: float, f: Callable[..., None], *args, **kwargs) -> Process:
         proc = Process(self.next_proc_number(), self, self._default_process_parent)
         self._proc_set |= set([proc])
         proc.exc_in(sim, time, f, *args, **kwargs)
         return proc
 
-    def fork_exec(self, sim: Simulator, f: Callable[[Thread], None], *args, **kwargs) -> Process:
+    def fork_exec(self, sim: Simulator, f: Callable[..., None], *args, **kwargs) -> Process:
         return self.fork_exec_in(sim, 0, f, *args, **kwargs)
 
     def run_file(self, sim: Simulator, file: File, user: UserAccount) -> None:

--- a/itsim/machine/process_management/daemon.py
+++ b/itsim/machine/process_management/daemon.py
@@ -1,7 +1,8 @@
+from .__init__ import _Service, _Thread
+
 from typing import Callable
 
 from itsim import _Node, ITObject
-from itsim.machine.process_management import _Service, _Thread
 from itsim.simulator import Simulator
 
 

--- a/itsim/machine/process_management/process.py
+++ b/itsim/machine/process_management/process.py
@@ -1,6 +1,7 @@
+from .__init__ import _Process
+
+from itsim.__init__ import _Node
 from itsim.simulator import Simulator
-from itsim.machine.node import _Node
-from itsim.machine.process_management import _Process
 from itsim.machine.process_management.thread import Thread
 from itsim.types import Interrupt
 from itsim.utils import assert_list
@@ -27,7 +28,7 @@ class Process(_Process):
     def children(self) -> Set[_Process]:
         return self._children
 
-    def exc_in(self, sim: Simulator, time: float, f: Callable[[Thread], None], *args, **kwargs) -> None:
+    def exc_in(self, sim: Simulator, time: float, f: Callable[[Thread], None], *args, **kwargs) -> Thread:
         t = Thread(sim, self, self._thread_counter)
         self._thread_counter += 1
         t.clone_in(time, f, *args, **kwargs)
@@ -35,7 +36,7 @@ class Process(_Process):
         # Not generally useful. For unit tests
         return t
 
-    def exc(self, sim: Simulator, f: Callable[[Thread], None], *args, **kwargs) -> None:
+    def exc(self, sim: Simulator, f: Callable[[Thread], None], *args, **kwargs) -> Thread:
         return self.exc_in(sim, 0, f, *args, **kwargs)
 
     def thread_complete(self, t: Thread):

--- a/itsim/machine/process_management/thread.py
+++ b/itsim/machine/process_management/thread.py
@@ -1,8 +1,9 @@
+from .__init__ import _Process, _Thread
+
 from itsim.simulator import Simulator
-from itsim.machine.process_management import _Process, _Thread
 from itsim.utils import assert_list
 
-from typing import Any, Callable, Set
+from typing import Any, Callable, Set, Tuple
 
 
 class Thread(_Thread):
@@ -21,7 +22,11 @@ class Thread(_Thread):
         self._n: int = n
         self._scheduled: Set[Callable[[], None]] = set()
 
-    def clone_in(self, time: float, f: Callable[[_Thread], None], *args, **kwargs) -> None:
+    def clone_in(self,
+                 time: float,
+                 f: Callable[[_Thread], None],
+                 *args,
+                 **kwargs) -> Tuple[Callable[[], None], Callable[[], None]]:
         # Convenient object for putting in the tracking set
         def func() -> None:
             f(self, *args, **kwargs)  # type: ignore
@@ -36,7 +41,7 @@ class Thread(_Thread):
         # Not generally useful. For unit tests
         return (func, call_and_callback)
 
-    def clone(self, f: Callable[[_Thread], None], *args, **kwargs) -> None:
+    def clone(self, f: Callable[[_Thread], None], *args, **kwargs) -> Tuple[Callable[[], None], Callable[[], None]]:
         return self.clone_in(0, f, *args, **kwargs)
 
     def exit_f(self, f: Callable[[], None]) -> None:

--- a/itsim/network/connection.py
+++ b/itsim/network/connection.py
@@ -1,5 +1,5 @@
-from itsim.network import _Connection
-from itsim.machine.process_management import _Service
+from .__init__ import _Connection
+from itsim.machine.process_management.__init__ import _Service
 
 
 class Connection(_Connection):

--- a/runtests
+++ b/runtests
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
     print("### Verifying type annotations and type coherence ###")
     try:
-        mypy_main(None, ["--ignore-missing-imports", "--strict-optional", "--incremental", "."])
+        mypy_main(None, ["--ignore-missing-imports", "--namespace-packages", "--strict-optional", "--incremental", "."])
         success_mypy = True
     except SystemExit as err:
         success_mypy = False


### PR DESCRIPTION
Adds an additional flag to the Mypy invocation to not enforce the requirement that every directory have an `__init__.py` to be checked. This causes `__init__.py` methods to not be read implicitly (by Mypy) when import statements call for modules, so the file name has to be added. This is not visually attractive, but it is functionally equivalent as far as I know and it is typically found in places where `ABC` classes with underscores in their name are being imported. There are some exceptions, but for cleanliness I believe those should be renamed anyway. If this PR is agreed to I will rename them.