### PR TITLE
Raise custom AddressError on as_address issue

### DIFF
--- a/itsim/machine/node.py
+++ b/itsim/machine/node.py
@@ -16,7 +16,8 @@ from itsim.machine.process_management.thread import Thread
 from itsim.machine.socket import Socket
 from itsim.machine.user_management.__init__ import UserAccount
 from itsim.simulator import Simulator
-from itsim.types import Address, AddressRepr, as_address, as_port, Cidr, Hostname, Port, PortRepr, Protocol
+from itsim.types import Address, AddressRepr, as_address, as_port, Cidr, Hostname, Port, PortRepr, Protocol, \
+    AddressError
 
 PORT_NULL = 0
 PORT_MAX = 2 ** 16 - 1
@@ -167,7 +168,7 @@ class Node(_Node):
         """
         try:
             return as_address(hostname)
-        except ValueError:
+        except AddressError:
             # TODO -- Implement name resolution.
             raise NotImplementedError()
 

--- a/itsim/machine/node.py
+++ b/itsim/machine/node.py
@@ -17,7 +17,7 @@ from itsim.machine.socket import Socket
 from itsim.machine.user_management.__init__ import UserAccount
 from itsim.simulator import Simulator
 from itsim.types import Address, AddressRepr, as_address, as_port, Cidr, Hostname, Port, PortRepr, Protocol, \
-    AddressError
+    is_ip_address
 
 PORT_NULL = 0
 PORT_MAX = 2 ** 16 - 1
@@ -166,9 +166,9 @@ class Node(_Node):
             IP address the name resolves to for this host. If resolution fails, the :py:class:`NameNotFound` exception
             is raised. If the given hostname is actually an IP address, then it is returned as is.
         """
-        try:
+        if is_ip_address(hostname):
             return as_address(hostname)
-        except AddressError:
+        else:
             # TODO -- Implement name resolution.
             raise NotImplementedError()
 

--- a/itsim/machine/socket.py
+++ b/itsim/machine/socket.py
@@ -5,7 +5,7 @@ import greensim
 from itsim.machine.__init__ import _Socket, _Node
 from itsim.network.location import LocationRepr, Location
 from itsim.network.packet import Packet
-from itsim.types import Port, Address, as_address, Payload, Hostname, AddressError
+from itsim.types import Port, Address, is_ip_address, as_address, Payload, Hostname
 
 
 class Timeout(Exception):
@@ -92,9 +92,9 @@ class Socket(_Socket):
         self._node._send_packet(self.port, Location(address_dest, dest.port), size, payload or {})
 
     def _resolve_destination_final(self, hostname_dest: Hostname) -> Address:
-        try:
+        if is_ip_address(hostname_dest):
             return as_address(hostname_dest)
-        except AddressError:
+        else:
             return self._node.resolve_name(hostname_dest)
 
     def _enqueue(self, packet: Packet) -> None:

--- a/itsim/machine/socket.py
+++ b/itsim/machine/socket.py
@@ -5,7 +5,7 @@ import greensim
 from itsim.machine.__init__ import _Socket, _Node
 from itsim.network.location import LocationRepr, Location
 from itsim.network.packet import Packet
-from itsim.types import Port, Address, as_address, Payload, Hostname
+from itsim.types import Port, Address, as_address, Payload, Hostname, AddressError
 
 
 class Timeout(Exception):
@@ -94,7 +94,7 @@ class Socket(_Socket):
     def _resolve_destination_final(self, hostname_dest: Hostname) -> Address:
         try:
             return as_address(hostname_dest)
-        except ValueError:
+        except AddressError:
             return self._node.resolve_name(hostname_dest)
 
     def _enqueue(self, packet: Packet) -> None:

--- a/itsim/types.py
+++ b/itsim/types.py
@@ -51,7 +51,7 @@ def as_address(ar: AddressRepr, rr: CidrRepr = "0.0.0.0/0") -> Address:
         machine = ip_address(0)
     elif isinstance(ar, int):
         if ar < 0 or ar >= 2 ** 32:
-            raise AddressError(ar)
+            raise ValueError(ar)
         machine = ip_address(ar)
     elif isinstance(ar, str):
         try:

--- a/itsim/types.py
+++ b/itsim/types.py
@@ -17,9 +17,16 @@ Payload = Mapping[str, object]
 
 class AddressError(Exception):
 
-    def __init__(self, attempt) -> None:
+    def __init__(self, attempt: AddressRepr) -> None:
         super().__init__()
         self.attempt = attempt
+
+
+class HostnameError(Exception):
+
+    def __init__(self, attempt: HostnameRepr) -> None:
+        super().__init__()
+        self.attmept = attempt
 
 
 def as_address(ar: AddressRepr, rr: CidrRepr = "0.0.0.0/0") -> Address:
@@ -92,13 +99,20 @@ def as_hostname(hr: HostnameRepr) -> Hostname:
     Returns a hostname from one of its representations: either an address or a string bearing a name formatted according
     to RFC 1034 of the IETF.
     """
-    try:
+    if is_ip_address(hr):
         return as_address(hr)
+    elif isinstance(hr, str) and len(hr) > 0:
+        return hr
+    else:
+        raise HostnameError(hr)
+
+
+def is_ip_address(ar: HostnameRepr) -> bool:
+    try:
+        as_address(ar)
+        return True
     except AddressError:
-        if isinstance(hr, str) and len(hr) > 0:
-            return hr
-        else:
-            raise
+        return False
 
 
 class Protocol(IntFlag):

--- a/tests/test_itsim.py
+++ b/tests/test_itsim.py
@@ -3,7 +3,7 @@ from ipaddress import ip_address
 import pytest
 
 from itsim.network.location import Location
-from itsim.types import as_address, as_hostname, as_port
+from itsim.types import as_address, as_hostname, as_port, AddressError
 
 
 def test_none_as_address():
@@ -17,9 +17,8 @@ def test_int_as_address():
 
 def test_int_as_address_nonV4():
     for n in [-1, 2**32]:
-        with pytest.raises(ValueError):
+        with pytest.raises(AddressError):
             as_address(n)
-            pytest.fail()
 
 
 def test_str_as_address():
@@ -44,6 +43,12 @@ def test_as_address_relative_squash():
         ("0.1.128.1", "10.10.128.0/17", "10.10.128.1")
     ]:
         assert as_address(a, r) == as_address(expected)
+
+
+def test_as_address_hostname():
+    for name in ["google.ca", "localhost"]:
+        with pytest.raises(AddressError):
+            as_address(name)
 
 
 def test_none_as_port():
@@ -76,9 +81,8 @@ def test_domain_as_hostname():
 
 
 def test_empty_as_hostname():
-    with pytest.raises(ValueError):
+    with pytest.raises(AddressError):
         assert as_hostname("")
-        pytest.fail()
 
 
 def test_location_none_none():

--- a/tests/test_itsim.py
+++ b/tests/test_itsim.py
@@ -17,7 +17,7 @@ def test_int_as_address():
 
 def test_int_as_address_nonV4():
     for n in [-1, 2**32]:
-        with pytest.raises(AddressError):
+        with pytest.raises(ValueError):
             as_address(n)
 
 

--- a/tests/test_itsim.py
+++ b/tests/test_itsim.py
@@ -3,7 +3,7 @@ from ipaddress import ip_address
 import pytest
 
 from itsim.network.location import Location
-from itsim.types import as_address, as_hostname, as_port, AddressError
+from itsim.types import as_address, as_hostname, as_port, AddressError, is_ip_address, HostnameError
 
 
 def test_none_as_address():
@@ -81,8 +81,25 @@ def test_domain_as_hostname():
 
 
 def test_empty_as_hostname():
-    with pytest.raises(AddressError):
+    with pytest.raises(HostnameError):
         assert as_hostname("")
+
+
+def test_ip_address_none():
+    assert is_ip_address(None)
+
+
+def test_ip_address_address():
+    assert is_ip_address("192.168.1.34")
+
+
+def test_ip_address_int():
+    assert is_ip_address(45)
+
+
+def test_ip_address_hostname():
+    assert not is_ip_address("localhost")
+    assert not is_ip_address("google.com")
 
 
 def test_location_none_none():


### PR DESCRIPTION
Bad address representations are now flagged with a custom exception
instead of relying on propagating the failure behaviour of ip_address.