### PR TITLE
Fix Socket lifecycle

### DIFF
--- a/itsim/machine/node.py
+++ b/itsim/machine/node.py
@@ -25,8 +25,6 @@ PORT_EPHEMERAL_MIN = 32768
 PORT_EPHEMERAL_UPPER = 61000
 NUM_PORTS_EPHEMERAL = PORT_EPHEMERAL_UPPER - PORT_EPHEMERAL_MIN
 
-SocketWeakRef = Callable[[], Optional[Socket]]
-
 
 class NameNotFound(Exception):
     """
@@ -65,7 +63,7 @@ class Node(_Node):
         super().__init__()
         self._interfaces: MutableMapping[Cidr, Interface] = OrderedDict()
         self.connected_to(Loopback(), "127.0.0.1")
-        self._sockets: MutableMapping[Port, SocketWeakRef] = OrderedDict()
+        self._sockets: MutableMapping[Port, weakref.ReferenceType] = OrderedDict()
         self._cycle_ports_ephemeral = cycle(range(PORT_EPHEMERAL_MIN, PORT_EPHEMERAL_UPPER))
 
         self._proc_set: Set[Process] = set()

--- a/itsim/machine/socket.py
+++ b/itsim/machine/socket.py
@@ -50,6 +50,13 @@ class Socket(_Socket):
         return self._port
 
     def __del__(self):
+        """
+        This is a safeguard against failure to properly close a socket before its reference is dropped. As a
+        :py:class:`Node` instance reserves the port associated to this socket, failure to close would leak the port.
+        Thus, the :py:class:`Node` that instantiated this socket through :py:meth:`Socket.bind` only keeps a weak
+        reference to it; when the owner drops the reference to the socket, it can thus be finalized, and the port can be
+        safely reclaimed.
+        """
         self.close()
 
     def __enter__(self):

--- a/itsim/machine/socket.py
+++ b/itsim/machine/socket.py
@@ -45,6 +45,8 @@ class Socket(_Socket):
         """
         Port reserved by this socket on the :py:class:`Node`.
         """
+        if self.is_closed:
+            raise ValueError("Socket is closed")
         return self._port
 
     def __del__(self):
@@ -61,9 +63,10 @@ class Socket(_Socket):
         """
         Closes the socket, relinquishing the resources it reserves on the :py:class:`Node` that instantiated it.
         """
-        self._node._deallocate_socket(self)
-        self._is_closed = True
-        self._packet_signal.turn_on()
+        if not self.is_closed:
+            self._node._deallocate_socket(self)
+            self._is_closed = True
+            self._packet_signal.turn_on()
 
     @property
     def is_closed(self) -> bool:

--- a/itsim/machine/socket.py
+++ b/itsim/machine/socket.py
@@ -45,9 +45,10 @@ class Socket(_Socket):
         """
         Port reserved by this socket on the :py:class:`Node`.
         """
-        if self.is_closed:
-            raise ValueError("Socket is closed")
         return self._port
+
+    def __del__(self):
+        self.close()
 
     def __enter__(self):
         return self

--- a/tests/integ/test_daemon_integ.py
+++ b/tests/integ/test_daemon_integ.py
@@ -1,7 +1,7 @@
 from itsim.machine.endpoint import Endpoint
-from itsim.machine.node import Socket
 from itsim.machine.process_management import _Thread
 from itsim.machine.process_management.daemon import Daemon
+from itsim.machine.socket import Socket
 from itsim.network.location import Location
 from itsim.network.packet import Packet
 from itsim.simulator import Simulator
@@ -38,7 +38,8 @@ def pack_send():
 
     for _ in range(n):
         for port in port_list:
-            bound_sock = end._sockets[as_port(port)]
+            bound_sock = end._sockets[as_port(port)]()
+            assert isinstance(bound_sock, Socket)
             bound_sock._enqueue(Packet(Location(), Location(None, bound_sock.port), 0, {}))
 
 

--- a/tests/integ/test_dhcp_integ.py
+++ b/tests/integ/test_dhcp_integ.py
@@ -1,6 +1,6 @@
 from greensim.random import normal, constant
 
-from itsim.machine.node import Socket
+from itsim.machine.socket import Socket
 from itsim.machine.process_management import _Thread
 from itsim.network.link import Link
 from itsim.network.location import Location
@@ -20,7 +20,8 @@ router = Router()
 
 def pack_send():
     global router
-    bound_sock = router._sockets[as_port(67)]
+    bound_sock = router._sockets[as_port(67)]()
+    assert isinstance(bound_sock, Socket)
 
     for req, res in DHCPDaemon.responses.items():
         bound_sock._enqueue(

--- a/tests/machine/test_node.py
+++ b/tests/machine/test_node.py
@@ -271,6 +271,8 @@ def test_socket_lost_should_be_closed(endpoint):
     with patch("itsim.machine.node.Socket", FakeSocket):
         socket = endpoint.bind(9887)
         assert not socket.is_closed
+        assert not endpoint.is_port_free(9887)
         socket = None
         gc.collect()
+        assert endpoint.is_port_free(9887)
         assert FakeSocket.num_close == 1

--- a/tests/machine/test_node.py
+++ b/tests/machine/test_node.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import enum
+import gc
 from unittest.mock import patch, call
 
 import pytest
@@ -255,3 +256,12 @@ def test_recv_socket_timeout_none(socket80):
 
 def test_recv_socket_timeout_fired(socket80):
     assert run_simulation_timeout(socket80, 50) == SimulationResult.TIMEOUT
+
+
+@patch("itsim.machine.socket.Socket")
+def test_socket_lost_should_be_closed(mock, endpoint):
+    socket = endpoint.bind(9887)
+    assert not socket.is_closed
+    socket = None
+    gc.collect()
+    assert mock.close.assert_called_once()


### PR DESCRIPTION
Now, if a Socket instance falls out of scope, it can be
garbage-collected, and this effectively closes the socket from the
perspective of the associated Node.