### PR TITLE
Rename process starting methods

### DIFF
--- a/tests/integ/test_broadcast.py
+++ b/tests/integ/test_broadcast.py
@@ -20,8 +20,8 @@ class EndpointChattering(Endpoint):
         super().__init__()
         self._peers: Set[Address] = set()
         self._interval_broadcast = uniform(3.0 * S, 6.0 * S)
-        self.fork_exec(sim, self.server)
-        self.fork_exec(sim, self.client)
+        self.run_proc(sim, self.server)
+        self.run_proc(sim, self.client)
 
     def server(self, thread: Thread):
         with thread.process.node.bind(Protocol.UDP, 10000) as socket:

--- a/tests/integ/test_packet_transfer.py
+++ b/tests/integ/test_packet_transfer.py
@@ -47,9 +47,9 @@ def test_packet_transfer():
 
     link = Link("10.11.12.0/24", latency=uniform(100 * MS, 200 * MS), bandwidth=constant(100 * MbPS))
     pinger = Endpoint().connected_to(link, "10.11.12.10")
-    pinger.fork_exec_in(sim, 0.1, client)
+    pinger.run_proc_in(sim, 0.1, client)
     ponger = Endpoint().connected_to(link, "10.11.12.20")
-    ponger.fork_exec(sim, server)
+    ponger.run_proc(sim, server)
 
     sim.run(10.0 * S)
     assert ledger == {"client", "server"}


### PR DESCRIPTION
Node.fork_exec(_in)? has been renamed to Node.run_proc(_in)?, and
Node.subscribe_networking_daemon has been renamed
Node.run_networking_daemon (as it runs processes in turn).