### PR TITLE
Logs

### DIFF
--- a/itsim/datastore/datastore.py
+++ b/itsim/datastore/datastore.py
@@ -3,7 +3,6 @@ import requests
 import json
 import os
 import logging
-from logging import Logger
 from collections import namedtuple
 from typing import Any, Optional
 from queue import Queue
@@ -63,7 +62,6 @@ class DatastoreRestClient(DatastoreClient):
                       logger_level,
                       logger_en_console,
                       logger_en_datastore)
-
 
     def __del__(self) -> None:
         """

--- a/itsim/datastore/datastore.py
+++ b/itsim/datastore/datastore.py
@@ -36,11 +36,19 @@ class DatastoreClient:
 
 class DatastoreRestClient(DatastoreClient):
 
-    def __init__(self, hostname: str = '0.0.0.0', port: int = 5000, sim_uuid: UUID = uuid4()) -> None:
+    def __init__(self,
+                 hostname: str = '0.0.0.0',
+                 port: int = 5000,
+                 sim_uuid: UUID = uuid4(),
+                 logger_name: str = 'itsim_logger',
+                 logger_level: int = logging.DEBUG,
+                 logger_en_console: bool = True,
+                 logger_en_datastore: bool = True) -> None:
         self._sim_uuid = sim_uuid
         self._headers = {'Accept': 'application/json'}
         self._url = f'http://{hostname}:{port}/'
         self._started_server = False
+        self._logger_name = 'itsim_logger'
 
         if not self.server_is_alive():
             _, self._db_file = tempfile.mkstemp(suffix=".sqlite")
@@ -48,6 +56,14 @@ class DatastoreRestClient(DatastoreClient):
             self._started_server = True
             self._url = f'http://{hostname}:{port}/'
             print(f"Couldn't find server, launching a local instance: {self._url}")
+
+        create_logger(logger_name,
+                      self._sim_uuid,
+                      self._url,
+                      logger_level,
+                      logger_en_console,
+                      logger_en_datastore)
+
 
     def __del__(self) -> None:
         """
@@ -96,17 +112,8 @@ class DatastoreRestClient(DatastoreClient):
             raise RuntimeError('Unable to start the datastore server')
         return port
 
-    # Creating the logger for console and datastore output
-    def create_logger(self,
-                      logger_name: str = __name__,
-                      console_level=logging.DEBUG,
-                      datastore_level=logging.DEBUG) -> Logger:
-
-        return create_logger(logger_name,
-                             self._sim_uuid,
-                             self._url,
-                             console_level,
-                             datastore_level)
+    def get_logger(self):
+        return logging.getLogger(self._logger_name)
 
     def load_item(self, item_type: str, uuid: UUID, from_time: Optional[str] = None,
                   to_time: Optional[str] = None) -> str:

--- a/itsim/logging.py
+++ b/itsim/logging.py
@@ -11,7 +11,7 @@ from typing import Any
     ITSIM logging provides console and rest datastore handlers for outputting logs (an additional handler for a local
     datastore could be added if required).
 """
-
+global logger_name
 
 class DatastoreRestHandler(Handler):
 
@@ -68,33 +68,37 @@ class DatastoreFormatter(Formatter):
 def create_logger(name: str,
                   sim_uuid: UUID,
                   datastore_server: str,
-                  console_level: int = logging.CRITICAL,
-                  datastore_level: int = logging.INFO) -> Logger:
+                  logger_level: int = logging.DEBUG,
+                  enable_console: bool = True,
+                  enable_datastore: bool = True) -> None:
     """
     Function for setting up the itsim logger (avoids subclassing the Python logging class)
-
-    :param name: Python logger name
-    :param sim_uuid: simulation's uuid
-    :param console_level: log level for the console output
-    :param datastore_level: log level for the datastore output
-    :param datastore_server: datastore's url (ex: 'http://localhost:5000/')
-    :return: logger
     """
 
-    logger = logging.getLogger(name)
+    global logger_name
+    logger_name = name
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
 
-    if console_level is not None:
+    if enable_console is not None:
         console_handler = logging.StreamHandler()
-        console_handler.setLevel(console_level)
+        console_handler.setLevel(logger_level)
         console_formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
         console_handler.setFormatter(console_formatter)
         logger.addHandler(console_handler)
 
-    if datastore_level is not None:
+    if enable_datastore is not None:
         datastore_formatter = DatastoreFormatter(sim_uuid)
         datastore_handler = DatastoreRestHandler(datastore_server)
-        datastore_handler.setLevel(datastore_level)
+        datastore_handler.setLevel(logger_level)
         datastore_handler.setFormatter(datastore_formatter)
         logger.addHandler(datastore_handler)
 
-    return logger
+
+def get_logger() -> Logger:
+    global logger_name
+
+    try:
+        return logging.getLogger(logger_name)
+    except NameError:
+        raise RuntimeError("A simulator needs to be created before getting the itsim logger using get_logger().")

--- a/itsim/logging.py
+++ b/itsim/logging.py
@@ -11,7 +11,8 @@ from typing import Any
     ITSIM logging provides console and rest datastore handlers for outputting logs (an additional handler for a local
     datastore could be added if required).
 """
-global logger_name
+logger_name = 'itsim_logger'
+
 
 class DatastoreRestHandler(Handler):
 
@@ -75,7 +76,6 @@ def create_logger(name: str,
     Function for setting up the itsim logger (avoids subclassing the Python logging class)
     """
 
-    global logger_name
     logger_name = name
     logger = logging.getLogger(logger_name)
     logger.setLevel(logging.DEBUG)
@@ -96,7 +96,6 @@ def create_logger(name: str,
 
 
 def get_logger() -> Logger:
-    global logger_name
 
     try:
         return logging.getLogger(logger_name)

--- a/itsim/network/service/dhcp/dhcp_client.py
+++ b/itsim/network/service/dhcp/dhcp_client.py
@@ -59,7 +59,6 @@ class DHCPClient(Daemon):
 
         self._logger.info(f"{self.__class__.__name__} __init__(): client initialized.")
 
-
     def run_client(self, thread: Thread) -> None:
         """
         Attempt and, if necessary retry, to resolve an :py:class:`~itsim.types.Address` for the

--- a/itsim/network/service/dhcp/dhcp_server.py
+++ b/itsim/network/service/dhcp/dhcp_server.py
@@ -132,8 +132,8 @@ class DHCPServer(Daemon):
         elif message == DHCP.REQUEST and address_maybe is not None:
             self._handle_request(socket, node_id, address_maybe)
         else:
-            self._logger.warning(f"{self.__class__.__name__} on_packet(): message isn't a DHCP.DISCOVER or DHCP.REQUEST,"
-                                 f" thus it's not handled and is getting dropped.")
+            self._logger.warning(f"{self.__class__.__name__} on_packet(): message isn't a DHCP.DISCOVER or "
+                                 f"DHCP.REQUEST, thus it's not handled and is getting dropped.")
             return
 
     def _handle_discover(self, socket: Socket, node_id: UUID, address_maybe: Optional[Address]) -> None:

--- a/itsim/simulator.py
+++ b/itsim/simulator.py
@@ -1,8 +1,19 @@
 import greensim
 from uuid import UUID
+from itsim.datastore.datastore import DatastoreRestClient
 
 
 class Simulator(greensim.Simulator):
+
+    def __init__(self,
+                 ds_hostname: str = '0.0.0.0',
+                 ds_port: int = 5000):
+        greensim.Simulator.__init__(self)
+        self._datastore = DatastoreRestClient(hostname=ds_hostname, port=ds_port, sim_uuid=self.uuid)
+
+    @property
+    def datastore(self):
+        return self._datastore
 
     # Todo: validate this in unit tests.
     @property

--- a/tests/integ/test_int_datastore.py
+++ b/tests/integ/test_int_datastore.py
@@ -4,20 +4,19 @@ from itsim.schemas.items import create_json_node, create_json_network_event
 from itsim.datastore.datastore import DatastoreRestClient
 from itsim.time import now_iso8601
 from time import sleep
+from itsim.logging import get_logger
+from itsim.simulator import Simulator
 
 
 def test_datastore_logger():
+    sim = Simulator()
+    logger = get_logger()
+
     from_time = now_iso8601()
-    sim_uuid = uuid4()
-
-    datastore = DatastoreRestClient(sim_uuid=sim_uuid)
-    logger = datastore.create_logger()
-
     logger.error('This is an error')    # Logging to console and datastore log table
-
     to_time = now_iso8601()             # Retrieving the log from the datastore
-    log = datastore.load_item('log', uuid=None, from_time=from_time, to_time=to_time)
 
+    log = sim.datastore.load_item('log', uuid=None, from_time=from_time, to_time=to_time)
     assert log.content == 'This is an error'
 
 


### PR DESCRIPTION
Added a few logs to DHCP, showing how to use the logger .

Quick "howto" reminder to use the datastore: 
- Launch a datastore instance: 
 $ python bin/itsim_serve_datastore.py --mydb.sqlite --host localhost --port 5000
- Use the logger in a simulation: 
ex: from itsim.logging import get_logger
     self._logger = get_logger()
     self._logger.info(f"{self.__class__.__name__} __init__(): client initialized.")
- Check your DB file for logs. I'm personally using this program for doing so: 
http://sqlitebrowser.org/
