### PR TITLE
Toy routing example

### DIFF
--- a/examples/xmas/beaconing.py
+++ b/examples/xmas/beaconing.py
@@ -21,29 +21,31 @@ size_dist = normal(100 * B, 300 * B)
 @malware
 def client(context: Context, router: Router) -> None:
     with context.node.bind(Protocol.UDP) as socket:
-        socket.send(Location("10.11.12.20", 9887), next(size_dist), {"content": "ping"})
-        try:
-            packet = socket.recv(1 * S)
-        except Timeout:
-            pytest.fail("Supposed to receive the packet before timeout.")
-        assert packet.payload["content"] == "pong"
+        while True:
+            socket.send(Location("10.11.12.20", 9887), next(size_dist), {"content": "ping"})
+            try:
+                packet = socket.recv(1 * S)
+            except Timeout:
+                pytest.fail("Supposed to receive the packet before timeout.")
+            assert packet.payload["content"] == "pong"
 
-        try:
-            socket.recv(5 * S)
-            pytest.fail()
-        except Timeout:
-            assert now() > 5.0
-        finally:
-            ledger.add("client")
+            try:
+                socket.recv(5 * S)
+                pytest.fail()
+            except Timeout:
+                assert now() > 5.0
+            finally:
+                ledger.add("client")
 
 
 @malware
 def server(context: Context) -> None:
     with context.node.bind(Protocol.UDP, 9887) as socket:
-        packet = socket.recv()
-        assert packet.payload["content"] == "ping"
-        socket.send(packet.source, 8, {"content": "pong"})
-        ledger.add("server")
+        while True:
+            packet = socket.recv()
+            assert packet.payload["content"] == "ping"
+            socket.send(packet.source, 8, {"content": "pong"})
+            ledger.add("server")
 
 
 def test_packet_transfer():
@@ -59,6 +61,6 @@ def test_packet_transfer():
     ponger = Endpoint().connected_to_static(link, "10.11.12.20", [route])
     ponger.run_proc(sim, server)
 
-    sim.run(10.0 * S)
+    sim.run(600.0 * S)
 
     assert ledger == {"client", "server"}

--- a/examples/xmas/beaconing.py
+++ b/examples/xmas/beaconing.py
@@ -1,0 +1,65 @@
+import pytest
+
+from greensim.random import uniform, constant
+
+from itsim import malware
+from itsim.software.context import Context
+from itsim.machine.endpoint import Endpoint
+from itsim.machine.socket import Timeout
+from itsim.network.location import Location
+from itsim.network.link import Link
+from itsim.network.router import Router
+from itsim.simulator import Simulator, now
+from itsim.types import Protocol
+from itsim.units import S, MS, MbPS
+
+ledger = set()
+
+
+@malware
+def client(context: Context, router: Router) -> None:
+    with context.node.bind(Protocol.UDP) as socket:
+        socket.send(router.location, 4, {"content": "ping",
+                                         Router.FINAL_DEST_FIELD: Location("10.11.12.20", 9887),
+                                         Router.MAC_FIELD: context.node.uuid})
+        try:
+            packet = socket.recv(1 * S)
+        except Timeout:
+            pytest.fail("Supposed to receive the packet before timeout.")
+        assert packet.byte_size == 8
+        assert packet.payload["content"] == "pong"
+
+        try:
+            socket.recv(5 * S)
+            pytest.fail()
+        except Timeout:
+            assert now() > 5.0
+        finally:
+            ledger.add("client")
+
+
+@malware
+def server(context: Context) -> None:
+    with context.node.bind(Protocol.UDP, 9887) as socket:
+        packet = socket.recv()
+        assert packet.byte_size == 4
+        assert packet.payload["content"] == "ping"
+        socket.send(packet.source, 8, {"content": "pong", Router.MAC_FIELD: packet.payload[Router.MAC_FIELD]})
+        ledger.add("server")
+
+
+def test_packet_transfer():
+    sim = Simulator()
+
+    link = Link("10.11.12.0/24", latency=uniform(100 * MS, 200 * MS), bandwidth=constant(100 * MbPS))
+    router = Router(sim, link)
+
+    pinger = Endpoint().connected_to_static(link, "10.11.12.10")
+    pinger.run_proc_in(sim, 0.1, client, router)
+
+    ponger = Endpoint().connected_to_static(link, "10.11.12.20")
+    ponger.run_proc(sim, server)
+
+    sim.run(10.0 * S)
+
+    assert ledger == {"client", "server"}

--- a/examples/xmas/beaconing.py
+++ b/examples/xmas/beaconing.py
@@ -11,20 +11,21 @@ from itsim.network.link import Link
 from itsim.network.router import Router
 from itsim.network.route import Relay
 from itsim.simulator import Simulator, now
-from itsim.types import Protocol
+from itsim.types import as_address, as_cidr, Protocol
 from itsim.units import B, S, MS, MbPS
 
 ledger = set()
 size_dist = normal(100 * B, 300 * B)
+ponger_addr = as_address("120.11.12.20")
 
 
 @malware
 def client(context: Context, router: Router) -> None:
     with context.node.bind(Protocol.UDP) as socket:
         while True:
-            socket.send(Location("10.11.12.20", 9887), next(size_dist), {"content": "ping"})
+            socket.send(Location(ponger_addr, 9887), next(size_dist), {"content": "ping"})
             try:
-                packet = socket.recv(1 * S)
+                packet = socket.recv(10 * S)
             except Timeout:
                 pytest.fail("Supposed to receive the packet before timeout.")
             assert packet.payload["content"] == "pong"
@@ -51,14 +52,22 @@ def server(context: Context) -> None:
 def test_packet_transfer():
     sim = Simulator()
 
-    link = Link("10.11.12.0/24", latency=uniform(100 * MS, 10 * MS), bandwidth=constant(100 * MbPS))
-    router = Router(sim, link)
-    route = Relay(router.addr, "0.0.0.0/0")
+    local_cidr = as_cidr("10.11.12.0/24")
+    internet_cidr = as_cidr("0.0.0.0/0")
+    local = Link(local_cidr, latency=uniform(100 * MS, 10 * MS), bandwidth=constant(100 * MbPS))
+    internet = Link(internet_cidr, latency=uniform(1 * S, 1 * S), bandwidth=constant(1000 * MbPS))
 
-    pinger = Endpoint().connected_to_static(link, "10.11.12.10", [route])
+    router = Router()
+    router.connected_to_static(local, 1)
+    router.connected_to_static(internet, "1.2.3.4")
+
+    pinger_route = Relay(router._interfaces[local_cidr].address, internet_cidr)
+    ponger_route = Relay(router._interfaces[internet_cidr].address, local_cidr)
+
+    pinger = Endpoint().connected_to_static(local, "10.11.12.10", [pinger_route])
     pinger.run_proc_in(sim, 0.1, client, router)
 
-    ponger = Endpoint().connected_to_static(link, "10.11.12.20", [route])
+    ponger = Endpoint().connected_to_static(internet, ponger_addr, [ponger_route])
     ponger.run_proc(sim, server)
 
     sim.run(600.0 * S)

--- a/itsim/machine/node.py
+++ b/itsim/machine/node.py
@@ -238,7 +238,7 @@ class Node(_Node):
             if packet.dest.port in self._sockets:
                 cast(Socket, self._sockets[packet.dest.port]())._enqueue(packet)
             else:
-                self.drop_packet(packet)
+                self.handle_packet_transit(packet)
         else:
             self.handle_packet_transit(packet)
 

--- a/itsim/network/interface.py
+++ b/itsim/network/interface.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from itsim.network.route import Route, Local
+from itsim.network.route import Route
 from itsim.network.link import Link
 from itsim.types import AddressRepr, Address, as_address, Cidr
 
@@ -61,7 +61,7 @@ class Interface:
         List of :py:class:`Route`s for this interface. A :py:class:`Local` route to the CIDR of the associated
         :py:class:`Link` is always present, even though it has not been explicitly specified.
         """
-        return [Local(self.cidr)] + self._routes
+        return self._routes
 
     @routes.setter
     def routes(self, fs: List[Route]):

--- a/itsim/network/interface.py
+++ b/itsim/network/interface.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from itsim.network.route import Route
+from itsim.network.route import Local, Route
 from itsim.network.link import Link
 from itsim.types import AddressRepr, Address, as_address, Cidr
 
@@ -61,7 +61,7 @@ class Interface:
         List of :py:class:`Route`s for this interface. A :py:class:`Local` route to the CIDR of the associated
         :py:class:`Link` is always present, even though it has not been explicitly specified.
         """
-        return self._routes
+        return [Local(self.cidr)] + self._routes
 
     @routes.setter
     def routes(self, fs: List[Route]):

--- a/itsim/network/router.py
+++ b/itsim/network/router.py
@@ -1,8 +1,5 @@
 from itsim.machine.node import Node
-from itsim.network.link import Link
 from itsim.network.packet import Packet
-from itsim.network.route import Local
-from itsim.simulator import Simulator
 
 
 class Router(Node):
@@ -15,11 +12,8 @@ class Router(Node):
     :param lan: LAN links connected to this router.
     """
 
-    def __init__(self, sim: Simulator, link: Link) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.addr = next(link.cidr.hosts())
-        self._port = 53
-        self._connect_to(link, self.addr, [Local("0.0.0.0/0")])
 
     def handle_packet_transit(self, packet: Packet) -> None:
         interface, address_hop = self._solve_transfer(packet.dest.hostname_as_address())

--- a/itsim/network/router.py
+++ b/itsim/network/router.py
@@ -1,4 +1,38 @@
 from itsim.machine.node import Node
+from itsim.machine.process_management.daemon import Daemon
+from itsim.machine.socket import Socket
+from itsim.network.link import Link
+from itsim.network.location import Location
+from itsim.network.packet import Packet
+from itsim.network.route import Relay
+from itsim.simulator import Simulator
+from itsim.software.context import Context
+from itsim.types import Protocol
+
+from typing import cast, MutableMapping
+
+
+class _PassThroughRoutingDaemon(Daemon):
+    def __init__(self):
+        super().__init__(self._route)
+        self._mac_map: MutableMapping[str, Location] = {}
+
+    def _route(self, context: Context, packet: Packet, socket: Socket):
+        if Router.MAC_FIELD not in packet.payload:
+            return
+
+        mac = str(packet.payload[Router.MAC_FIELD])
+        if Router.FINAL_DEST_FIELD in packet.payload and isinstance(packet.payload[Router.FINAL_DEST_FIELD], Location):
+            if mac not in self._mac_map:
+                self._mac_map[mac] = packet.source
+
+            dest = cast(Location, packet.payload[Router.FINAL_DEST_FIELD])
+        else:
+            if mac not in self._mac_map:
+                return
+            dest = self._mac_map[mac]
+
+        socket.send(dest, packet.byte_size, packet.payload)
 
 
 class Router(Node):
@@ -11,5 +45,13 @@ class Router(Node):
     :param lan: LAN links connected to this router.
     """
 
-    def __init__(self) -> None:
+    FINAL_DEST_FIELD = "final_dest"
+    MAC_FIELD = "mac"
+
+    def __init__(self, sim: Simulator, link: Link) -> None:
         super().__init__()
+        addr = next(link.cidr.hosts())
+        port = 53
+        self._connect_to(link, addr, [Relay(addr, link.cidr)])
+        self.run_networking_daemon(sim, _PassThroughRoutingDaemon(), Protocol.UDP, port)
+        self.location = Location(addr, port)

--- a/itsim/network/router.py
+++ b/itsim/network/router.py
@@ -1,37 +1,8 @@
 from itsim.machine.node import Node
-from itsim.machine.process_management.daemon import Daemon
-from itsim.machine.socket import Socket
 from itsim.network.link import Link
-from itsim.network.location import Location
 from itsim.network.packet import Packet
 from itsim.network.route import Local
 from itsim.simulator import Simulator
-from itsim.software.context import Context
-
-from typing import cast, MutableMapping
-
-
-class _PassThroughRoutingDaemon(Daemon):
-    def __init__(self):
-        super().__init__(self._route)
-        self._mac_map: MutableMapping[str, Location] = {}
-
-    def _route(self, context: Context, packet: Packet, socket: Socket):
-        if Router.MAC_FIELD not in packet.payload:
-            return
-
-        mac = str(packet.payload[Router.MAC_FIELD])
-        if Router.FINAL_DEST_FIELD in packet.payload and isinstance(packet.payload[Router.FINAL_DEST_FIELD], Location):
-            if mac not in self._mac_map:
-                self._mac_map[mac] = packet.source
-
-            dest = cast(Location, packet.payload[Router.FINAL_DEST_FIELD])
-        else:
-            if mac not in self._mac_map:
-                return
-            dest = self._mac_map[mac]
-
-        socket.send(dest, packet.byte_size, packet.payload)
 
 
 class Router(Node):
@@ -43,9 +14,6 @@ class Router(Node):
     :param wan: WAN interface, articulated by a ``itsim.network.Link`` instance.
     :param lan: LAN links connected to this router.
     """
-
-    FINAL_DEST_FIELD = "final_dest"
-    MAC_FIELD = "mac"
 
     def __init__(self, sim: Simulator, link: Link) -> None:
         super().__init__()

--- a/tests/integ/test_broadcast.py
+++ b/tests/integ/test_broadcast.py
@@ -5,6 +5,7 @@ from greensim.random import uniform, constant
 from itsim.software.context import Context
 from itsim.machine.endpoint import Endpoint
 from itsim.network.link import Link
+from itsim.network.route import Local
 from itsim.simulator import Simulator, advance
 from itsim.types import Address, as_address
 from itsim.types import Protocol
@@ -44,7 +45,10 @@ class EndpointChattering(Endpoint):
 def test_broadcast():
     sim = Simulator()
     link = Link("10.11.0.0/16", uniform(100 * MS, 200 * MS), constant(100 * MbPS))
-    endpoints = [EndpointChattering(sim).connected_to_static(link, as_address(n, link.cidr)) for n in NUMS_HOST]
+    endpoints = [
+        EndpointChattering(sim).connected_to_static(link, as_address(n, link.cidr), [Local("0.0.0.0/0")])
+        for n in NUMS_HOST
+    ]
     all_addresses = set(as_address(n, link.cidr) for n in NUMS_HOST)
 
     sim.run(10 * S)

--- a/tests/integ/test_dhcp_exchange.py
+++ b/tests/integ/test_dhcp_exchange.py
@@ -2,6 +2,7 @@ from greensim.random import uniform, constant
 
 from itsim.machine.endpoint import Endpoint
 from itsim.network.link import Link
+from itsim.network.route import Local
 from itsim.network.router import Router
 from itsim.network.service.dhcp.client import DHCPClient
 from itsim.network.service.dhcp.server import DHCPServer
@@ -18,10 +19,10 @@ def test_dhcp_exchange():
     sim = Simulator()
 
     link = Link("10.1.128.0/18", uniform(100 * MS, 200 * MS), constant(100 * MbPS))
-    router = Router(sim, link).connected_to_static(link, "10.1.128.1")
+    router = Router(sim, link).connected_to_static(link, "10.1.128.1", [Local("0.0.0.0/0")])
     router.networking_daemon(sim, Protocol.UDP, 67)(DHCPServer(100, link.cidr, as_address("10.1.128.1")))
 
-    endpoints = [Endpoint().connected_to_static(link, as_address(None)) for n in range(3)]
+    endpoints = [Endpoint().connected_to_static(link, as_address(None), [Local("0.0.0.0/0")]) for n in range(3)]
     for endpoint in endpoints:
         endpoint.schedule_daemon_in(sim, 0.0, DHCPClient(endpoint._interfaces[link.cidr]))
         assert set(endpoint.addresses()) == set_addresses("127.0.0.1", link.cidr.network_address)

--- a/tests/integ/test_dhcp_exchange.py
+++ b/tests/integ/test_dhcp_exchange.py
@@ -18,7 +18,7 @@ def test_dhcp_exchange():
     sim = Simulator()
 
     link = Link("10.1.128.0/18", uniform(100 * MS, 200 * MS), constant(100 * MbPS))
-    router = Router().connected_to_static(link, "10.1.128.1")
+    router = Router(sim, link).connected_to_static(link, "10.1.128.1")
     router.networking_daemon(sim, Protocol.UDP, 67)(DHCPServer(100, link.cidr, as_address("10.1.128.1")))
 
     endpoints = [Endpoint().connected_to_static(link, as_address(None)) for n in range(3)]

--- a/tests/integ/test_dhcp_exchange.py
+++ b/tests/integ/test_dhcp_exchange.py
@@ -19,7 +19,7 @@ def test_dhcp_exchange():
     sim = Simulator()
 
     link = Link("10.1.128.0/18", uniform(100 * MS, 200 * MS), constant(100 * MbPS))
-    router = Router(sim, link).connected_to_static(link, "10.1.128.1", [Local("0.0.0.0/0")])
+    router = Router().connected_to_static(link, "10.1.128.1", [Local("0.0.0.0/0")])
     router.networking_daemon(sim, Protocol.UDP, 67)(DHCPServer(100, link.cidr, as_address("10.1.128.1")))
 
     endpoints = [Endpoint().connected_to_static(link, as_address(None), [Local("0.0.0.0/0")]) for n in range(3)]

--- a/tests/integ/test_packet_transfer.py
+++ b/tests/integ/test_packet_transfer.py
@@ -6,6 +6,7 @@ from itsim.software.context import Context
 from itsim.machine.endpoint import Endpoint
 from itsim.machine.socket import Timeout
 from itsim.network.link import Link
+from itsim.network.route import Local
 from itsim.simulator import Simulator, now
 from itsim.types import Protocol
 from itsim.units import S, MS, MbPS
@@ -45,9 +46,9 @@ def test_packet_transfer():
     sim = Simulator()
 
     link = Link("10.11.12.0/24", latency=uniform(100 * MS, 200 * MS), bandwidth=constant(100 * MbPS))
-    pinger = Endpoint().connected_to_static(link, "10.11.12.10")
+    pinger = Endpoint().connected_to_static(link, "10.11.12.10", [Local("0.0.0.0/0")])
     pinger.run_proc_in(sim, 0.1, client)
-    ponger = Endpoint().connected_to_static(link, "10.11.12.20")
+    ponger = Endpoint().connected_to_static(link, "10.11.12.20", [Local("0.0.0.0/0")])
     ponger.run_proc(sim, server)
 
     sim.run(10.0 * S)

--- a/tests/machine/test_node.py
+++ b/tests/machine/test_node.py
@@ -56,8 +56,7 @@ ADDRESS_LARGE = as_address("10.10.192.54")
 @pytest.fixture
 def endpoint_2links(endpoint, link_small, link_large):
     return endpoint.connected_to_static(link_small, 4) \
-                   .connected_to_static(link_large, ADDRESS_LARGE, [Relay("10.10.192.78", CIDR_LARGE)]) \
-                   .connected_to_static(link_small, ADDRESS_SMALL, [Relay("192.168.1.23", CIDR_SMALL)])
+                   .connected_to_static(link_large, ADDRESS_LARGE, [Relay("10.10.192.1")])
 
 
 def test_node_addresses(endpoint_2links):
@@ -262,8 +261,9 @@ def test_recv_socket_timeout_fired(socket80):
 
 def test_send_packet(endpoint_2links, link_small, link_large):
     for source, dest, link, relay in [
-        (ADDRESS_SMALL, "192.168.1.67", link_small, "192.168.1.23"),
-        (ADDRESS_LARGE, "10.10.192.245", link_large, "10.10.192.78")
+            (ADDRESS_SMALL, "192.168.1.67", link_small, "192.168.1.67"),
+            (ADDRESS_LARGE, "10.10.192.245", link_large, "10.10.192.245"),
+            (ADDRESS_LARGE, "172.92.0.2", link_large, "10.10.192.1")
     ]:
         with patch.object(link, "_transfer_packet") as mock:
             loc_dest = Location(dest, 443)
@@ -277,6 +277,12 @@ def test_solve_transfer_local(endpoint_2links):
         interface, hop = endpoint_2links._solve_transfer(address)
         assert interface.cidr == as_cidr(cidr_r)
         assert hop == address
+
+
+def test_solve_transfer_beyond(endpoint_2links):
+    interface, hop = endpoint_2links._solve_transfer(as_address("172.99.0.2"))
+    assert interface.cidr == as_cidr("10.10.128.0/17")
+    assert hop == as_address("10.10.192.1")
 
 
 def test_solve_transfer_no_route(endpoint, link_small):

--- a/tests/network/test_interface.py
+++ b/tests/network/test_interface.py
@@ -2,7 +2,7 @@ import pytest
 
 from greensim.random import constant
 
-from itsim.network.route import Local, Relay
+from itsim.network.route import Relay
 from itsim.network.interface import Interface
 from itsim.network.link import Link
 from itsim.types import as_cidr, as_address
@@ -37,9 +37,9 @@ def test_set_address_reroot(interface_wo_address):
 
 
 def test_list_routes_unconnected(interface_wo_address):
-    assert list(interface_wo_address.routes) == [Local(CIDR_LOCAL)]
+    assert list(interface_wo_address.routes) == []
 
 
 def test_list_routes_non_trivial(interface_wo_address):
     interface_wo_address.routes = [Relay("192.168.1.1", "0.0.0.0/0")]
-    assert list(interface_wo_address.routes) == [Local(CIDR_LOCAL), Relay("192.168.1.1")]
+    assert list(interface_wo_address.routes) == [Relay("192.168.1.1")]

--- a/tests/network/test_interface.py
+++ b/tests/network/test_interface.py
@@ -2,7 +2,7 @@ import pytest
 
 from greensim.random import constant
 
-from itsim.network.route import Relay
+from itsim.network.route import Local, Relay
 from itsim.network.interface import Interface
 from itsim.network.link import Link
 from itsim.types import as_cidr, as_address
@@ -37,9 +37,9 @@ def test_set_address_reroot(interface_wo_address):
 
 
 def test_list_routes_unconnected(interface_wo_address):
-    assert list(interface_wo_address.routes) == []
+    assert list(interface_wo_address.routes) == [Local(CIDR_LOCAL)]
 
 
 def test_list_routes_non_trivial(interface_wo_address):
     interface_wo_address.routes = [Relay("192.168.1.1", "0.0.0.0/0")]
-    assert list(interface_wo_address.routes) == [Relay("192.168.1.1")]
+    assert list(interface_wo_address.routes) == [Local(CIDR_LOCAL), Relay("192.168.1.1")]

--- a/tests/test_beaconing.py
+++ b/tests/test_beaconing.py
@@ -1,0 +1,1 @@
+../examples/xmas/beaconing.py


### PR DESCRIPTION
Added some simple routing to the `Router` class and created a modification of `tests/integ/test_packet_transfer.py` called `examples/xmas/beaconing.py` that shows a `Packet` getting routed from one malware process to another. It is run in the test suite via the soft link `tests/test_beaconing.py`