### PR TITLE
Add Singleton metaclass and make DatastoreRestClient a Singleton

### DIFF
--- a/tests/test_itsim.py
+++ b/tests/test_itsim.py
@@ -1,0 +1,46 @@
+from itsim import Singleton
+
+
+def test_singleton_instantiation():
+    class Test1(metaclass=Singleton):
+        pass
+
+    assert Test1() is Test1()
+
+
+def test_singleton_no_overlap():
+    class Test1(metaclass=Singleton):
+        pass
+
+    class Test2(metaclass=Singleton):
+        pass
+
+    assert not Test1() is Test2()
+
+
+def test_singleton_reset():
+    class Test1(metaclass=Singleton):
+        pass
+
+    class Test2(metaclass=Singleton):
+        pass
+
+    a = Test1()
+    b = Test2()
+
+    Singleton.reset(Test1)
+
+    assert not Test1() is a
+    assert Test2() is b
+
+
+def test_has():
+    class Test1(metaclass=Singleton):
+        pass
+
+    class Test2(metaclass=Singleton):
+        pass
+
+    Test1()
+    assert Singleton.has_instance(Test1)
+    assert not Singleton.has_instance(Test2)


### PR DESCRIPTION
This is set to merge into https://github.com/ElementAI/itsim/pull/59 for now so that the diff is sane after changing file names.

As part of [this card](https://trello.com/c/SFZoiaJ1), I decided to isolate the singleton logic so that it is not contained within the factory class. Through searching I found a good use of the [metaclasses](https://docs.python.org/3/reference/datamodel.html?highlight=metaclass#metaclasses) that makes the process simple. This PR adds the new `Singleton` class, applies it to `DatastoreRestClient`, and adds tests. This required making calls to the `__del__` method explicit, so I proposed renaming it and adding a line to remove the client from the `Singleton` storage so a new connection can be opened without further interference.

Docstrings will come next, but the code should be ready for review as is 